### PR TITLE
Add option which disable remove encoding even it became no need

### DIFF
--- a/Auto Encoding for Ruby.sublime-settings
+++ b/Auto Encoding for Ruby.sublime-settings
@@ -17,5 +17,8 @@
   // already has an encoding declaration. So if you change the default encoding
   // declaration above, you must change this accordingly. Don't forget to escape
   // character classes as "\s" to "\\s", for example.
-  "encoding_declaration_regex": "^\\s*#\\s*encoding\\s*:\\s*utf-8\\s*$"
+  "encoding_declaration_regex": "^\\s*#\\s*encoding\\s*:\\s*utf-8\\s*$",
+
+  // Set to false if you want to keep encoding declaration even it became not need
+  "remove_encoding_declaration": true
 }

--- a/README.markdown
+++ b/README.markdown
@@ -70,7 +70,8 @@ Although this plugin works out of the box, you can tweak it to your needs. Just 
   ],
 
   "encoding_declaration": "#encoding: utf-8\n\n",
-  "encoding_declaration_regex": "^\\s*#\\s*encoding\\s*:\\s*utf-8\\s*$"
+  "encoding_declaration_regex": "^\\s*#\\s*encoding\\s*:\\s*utf-8\\s*$",
+  "remove_encoding_declaration": true
 }
 ```
 
@@ -97,7 +98,8 @@ This is an example of a changing in this setting:
 ```json
 {
   "encoding_declaration": "# -*- encoding : utf-8 -*-\n\n",
-  "encoding_declaration_regex": "^\\s*#\\s*-\\*-\\s*encoding\\s*:\\s*utf-8\\s*-\\*-\\s*$"
+  "encoding_declaration_regex": "^\\s*#\\s*-\\*-\\s*encoding\\s*:\\s*utf-8\\s*-\\*-\\s*$",
+  "remove_encoding_declaration": false
 }
 ```
 

--- a/auto_encoding_for_ruby.py
+++ b/auto_encoding_for_ruby.py
@@ -67,6 +67,9 @@ class AutoEncodingForRuby(sublime_plugin.EventListener):
     view.end_edit(edit)
 
   def remove_encoding_declaration_on_the_first_line_of(self, view):
+    if not self.get_settings("remove_encoding_declaration", view):
+      return
+
     edit = view.begin_edit()
     self.erase_first_line_of(view, edit)
 


### PR DESCRIPTION
Add option which disable remove encoding even it became no need, default setting still remove like before action, but at least give user a option if user wish to make some frequently changed ruby code more stable at first line especially in Git change history.
