### PR TITLE
Added https://github.com/tadast/sublime-rails-snippets to default syntax

### DIFF
--- a/Auto Encoding for Ruby.sublime-settings
+++ b/Auto Encoding for Ruby.sublime-settings
@@ -7,7 +7,8 @@
   [
     "Packages/Ruby/Ruby.tmLanguage",
     "Packages/Rails/Ruby on Rails.tmLanguage",
-    "Packages/RSpec/RSpec.tmLanguage"
+    "Packages/RSpec/RSpec.tmLanguage",
+    "Packages/Ruby on Rails snippets/Ruby on Rails.tmLanguage"
   ],
 
   // This is the encoding declaration that will be inserted on the top of your files.


### PR DESCRIPTION
This is a pretty extensive library but it requires using separate syntax space for some files and that makes autoencoding to not recognize them. 
