### PR TITLE
More granular configuration of when to check encoding

### DIFF
--- a/Auto Encoding for Ruby.sublime-settings
+++ b/Auto Encoding for Ruby.sublime-settings
@@ -27,6 +27,12 @@
   // Set to false if you want to keep encoding declaration even it became not need
   "remove_encoding_declaration": true,
 
-  // Set to false if you don't want to checking encoding on every keystroke
-  "checking_encoding_on_pre_save_only": false
+  // Set to false if you don't want to check encoding when opening a file
+  "check_encoding_on_load": true,
+
+  // Set to false if you don't want to check encoding on every keystroke
+  "check_encoding_on_keystroke": true,
+
+  // Set to false if you don't want to check encoding when saving a file
+  "check_encoding_on_save": true
 }

--- a/README.markdown
+++ b/README.markdown
@@ -72,7 +72,9 @@ Although this plugin works out of the box, you can tweak it to your needs. Just 
   "encoding_declaration": "# encoding: utf-8\n\n",
   "encoding_declaration_regex": "^\\s*#\\s*encoding\\s*:\\s*utf-8\\s*$",
   "remove_encoding_declaration": true,
-  "checking_encoding_on_pre_save_only": false
+  "check_encoding_on_load": true,
+  "check_encoding_on_keystroke": true,
+  "check_encoding_on_save": true
 }
 ```
 
@@ -101,7 +103,9 @@ This is an example of a changing in this setting:
   "encoding_declaration": "# -*- encoding : utf-8 -*-\n\n",
   "encoding_declaration_regex": "^\\s*#\\s*-\\*-\\s*encoding\\s*:\\s*utf-8\\s*-\\*-\\s*$",
   "remove_encoding_declaration": false,
-  "checking_encoding_on_pre_save_only": true
+  "check_encoding_on_load": true,
+  "check_encoding_on_keystroke": true,
+  "check_encoding_on_save": true
 }
 ```
 

--- a/auto_encoding_for_ruby.py
+++ b/auto_encoding_for_ruby.py
@@ -7,14 +7,15 @@ class AutoEncodingForRuby(sublime_plugin.EventListener):
     self.settings = sublime.load_settings("Auto Encoding for Ruby.sublime-settings")
 
   def on_load(self, view):
-    self.handle_encoding_declaration_on(view)
+    if self.get_settings("check_encoding_on_load", view):
+      self.handle_encoding_declaration_on(view)
 
   def on_modified(self, view):
-    if not self.get_settings("checking_encoding_on_pre_save_only", view):
+    if self.get_settings("check_encoding_on_keystroke", view):
       self.handle_encoding_declaration_on(view)
 
   def on_pre_save(self, view):
-    if self.get_settings("checking_encoding_on_pre_save_only", view):
+    if self.get_settings("check_encoding_on_save", view):
       self.handle_encoding_declaration_on(view)
 
   def handle_encoding_declaration_on(self, view):


### PR DESCRIPTION
When opening an existing file (typically when browsing a gem via `bundle open`), this plugin would change the files right as I opened the file. I didn’t like that.

So I changed the plugin so you can configure when it should check the encoding:
- `check_encoding_on_load`
- `check_encoding_on_keystroke`
- `check_encoding_on_save`

Note that this breaks compatibility with the existing `checking_encoding_on_pre_save_only` configuration option. If wanted, it should be possible to add check for that old option along with the new ones.

I saw no way to keep the old configuration option, as its name ends with “_only”.
